### PR TITLE
Feat/refactor 카카오톡 공유 기능 리팩토링

### DIFF
--- a/src/Components/PostShare/PostShare.js
+++ b/src/Components/PostShare/PostShare.js
@@ -56,6 +56,7 @@ const PostShare = ({ isFixedShare, detailData }) => {
           {
             title: '웹으로 보기',
             link: {
+              mobileWebUrl: `${DEFAULT_URL}/${detailData.id}`,
               webUrl: `${DEFAULT_URL}/${detailData.id}`,
             },
           },

--- a/src/Components/PostShare/PostShare.js
+++ b/src/Components/PostShare/PostShare.js
@@ -3,6 +3,8 @@ import parse from 'html-react-parser';
 import { style } from './PostShareStyle';
 import { removeHTMLTagFromString } from 'Common/removeHTMLTag';
 
+const DEFAULT_URL = 'https://determined-volhard-ea03ee.netlify.app/detail';
+
 const PostShare = ({ isFixedShare, detailData }) => {
   const [shareContainerStyle, setShareContainerStyle] = useState({
     position: 'relative',
@@ -46,15 +48,15 @@ const PostShare = ({ isFixedShare, detailData }) => {
           description: description,
           imageUrl: `${img}`,
           link: {
-            mobileWebUrl: `http://localhost:3000/detail/${detailData.id}`,
-            webUrl: `http://localhost:3000/detail/${detailData.id}`,
+            mobileWebUrl: `${DEFAULT_URL}/${detailData.id}`,
+            webUrl: `${DEFAULT_URL}/${detailData.id}`,
           },
         },
         buttons: [
           {
             title: '웹으로 보기',
             link: {
-              webUrl: `http://localhost:3000/detail/${detailData.id}`,
+              webUrl: `${DEFAULT_URL}/${detailData.id}`,
             },
           },
         ],

--- a/src/Pages/DetailPage/DetailPage.js
+++ b/src/Pages/DetailPage/DetailPage.js
@@ -1,18 +1,18 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import Header from 'Components/Header/Header';
 import { style } from './DetailPageStyle';
-import Tag from 'Components/Tag/Tag';
-import CommentView from 'Components/Comment/CommentView/CommentView';
 import parse from 'html-react-parser';
 import MenuApi from 'Common/api';
 import { useSelector } from 'react-redux';
 import useGetData from 'Hooks/useGetData';
+import Tag from 'Components/Tag/Tag';
+import Header from 'Components/Header/Header';
+import CommentView from 'Components/Comment/CommentView/CommentView';
 import DetailSkeleton from 'Components/DetailSkeleton/DetailSkeleton';
 import DetailAction from 'Components/DetailAction/DetailAction';
 import PostShare from 'Components/PostShare/PostShare';
-import { throttle } from 'lodash';
 import CommentWrite from 'Components/Comment/CommentWrite/CommentWrite';
 import Modal from 'Components/Modal/Modal';
+import { throttle } from 'lodash';
 import avatar from 'Assets/avatar.png';
 
 const DetailPage = ({ history }) => {


### PR DESCRIPTION
# PR 제목

<br/>

## 해당 이슈 📎


## 변경 사항 🛠

- 카카오톡 공유 API의 Default URL을 배포한 주소로 변경하여 공유를 했을 때 웹으로 보기 버튼을 클릭하면 정상적으로 게시글이 보여지도록 함

<br/>

## 리뷰어 참고 사항 🙋‍♀️

> 없음.

<br/>

